### PR TITLE
CCI-33 Disable clinic locator module from the USSD flow

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -7,6 +7,7 @@ go;
 
 /*jshint -W083 */
 var _ = require('lodash');
+var Q = require('q');
 var moment = require('moment');
 var vumigo = require('vumigo_v02');
 var Choice = vumigo.states.Choice;
@@ -219,23 +220,23 @@ go.utils = {
                 var update = JSON.parse(json_result.data);
                 var clean = true;
                 var patch_url;
-
+                
                 if (update.objects.length === 1) {
-                if (update.objects[0].lang !== lang) {
-                    patch_url = 'subscription/' + update.objects[0].id + '/';
-                    clean = false;
-                    update = {
-                        "lang": lang
-                    };
+                    if (update.objects[0].lang !== lang) {
+                        patch_url = 'subscription/' + update.objects[0].id + '/';
+                        clean = false;
+                        update = {
+                            "lang": lang
+                        };
                 }
                 } else if (update.objects.length >= 1) {
-                for (i=0; i<update.objects.length; i++) {
-                    if (update.objects[i].lang !== lang){
-                        update.objects[i].lang = lang;
-                        clean = false;
-                        patch_url = 'subscription/';
+                    for (i=0; i<update.objects.length; i++) {
+                        if (update.objects[i].lang !== lang){
+                            update.objects[i].lang = lang;
+                            clean = false;
+                            patch_url = 'subscription/';
+                        }
                     }
-                }
                 }
 
                 if (!clean) {

--- a/go-app-ussd.js
+++ b/go-app-ussd.js
@@ -7,6 +7,7 @@ go;
 
 /*jshint -W083 */
 var _ = require('lodash');
+var Q = require('q');
 var moment = require('moment');
 var vumigo = require('vumigo_v02');
 var Choice = vumigo.states.Choice;
@@ -219,23 +220,23 @@ go.utils = {
                 var update = JSON.parse(json_result.data);
                 var clean = true;
                 var patch_url;
-
+                
                 if (update.objects.length === 1) {
-                if (update.objects[0].lang !== lang) {
-                    patch_url = 'subscription/' + update.objects[0].id + '/';
-                    clean = false;
-                    update = {
-                        "lang": lang
-                    };
+                    if (update.objects[0].lang !== lang) {
+                        patch_url = 'subscription/' + update.objects[0].id + '/';
+                        clean = false;
+                        update = {
+                            "lang": lang
+                        };
                 }
                 } else if (update.objects.length >= 1) {
-                for (i=0; i<update.objects.length; i++) {
-                    if (update.objects[i].lang !== lang){
-                        update.objects[i].lang = lang;
-                        clean = false;
-                        patch_url = 'subscription/';
+                    for (i=0; i<update.objects.length; i++) {
+                        if (update.objects[i].lang !== lang){
+                            update.objects[i].lang = lang;
+                            clean = false;
+                            patch_url = 'subscription/';
+                        }
                     }
-                }
                 }
 
                 if (!clean) {
@@ -391,7 +392,8 @@ go.app = function() {
                 characters_per_page: 160,
                 options_per_page: null,
                 choices: [
-                    new Choice('state_healthsites', $('Find a clinic')),
+                    /*** Clinic locator option disabled for now (CCI-33) ***
+                     new Choice('state_healthsites', $('Find a clinic')),*/
                     new Choice('state_end', $('Speak to an expert for FREE')),
                     new Choice(
                         'state_op',
@@ -468,6 +470,7 @@ go.app = function() {
             });
         });
 
+        /*** Clinic locator option disabled for now (CCI-33) ***
         self.add('state_healthsites', function(name){
             return new ChoiceState(name, {
                 question: $([
@@ -483,7 +486,7 @@ go.app = function() {
                     return choice.value;
                 }
             });
-        });
+        });*/
 
         // ChoiceState st-F1
         self.states.add('state_op', function(name) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-watch": "~0.6.0",
     "grunt": "~0.4.4",
     "grunt-mocha-test": "~0.10.0",
-    "grunt-contrib-jshint": "~0.9.2",
+    "grunt-contrib-jshint": "~0.12.0",
     "grunt-cli": "~0.1.13"
   }
 }

--- a/src/ussd_app.js
+++ b/src/ussd_app.js
@@ -127,7 +127,8 @@ go.app = function() {
                 characters_per_page: 160,
                 options_per_page: null,
                 choices: [
-                    new Choice('state_healthsites', $('Find a clinic')),
+                    /*** Clinic locator option disabled for now (CCI-33) ***
+                     new Choice('state_healthsites', $('Find a clinic')),*/
                     new Choice('state_end', $('Speak to an expert for FREE')),
                     new Choice(
                         'state_op',
@@ -204,6 +205,7 @@ go.app = function() {
             });
         });
 
+        /*** Clinic locator option disabled for now (CCI-33) ***
         self.add('state_healthsites', function(name){
             return new ChoiceState(name, {
                 question: $([
@@ -219,7 +221,7 @@ go.app = function() {
                     return choice.value;
                 }
             });
-        });
+        });*/
 
         // ChoiceState st-F1
         self.states.add('state_op', function(name) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 /*jshint -W083 */
 var _ = require('lodash');
+var Q = require('q');
 var moment = require('moment');
 var vumigo = require('vumigo_v02');
 var Choice = vumigo.states.Choice;
@@ -212,23 +213,23 @@ go.utils = {
                 var update = JSON.parse(json_result.data);
                 var clean = true;
                 var patch_url;
-
+                
                 if (update.objects.length === 1) {
-                if (update.objects[0].lang !== lang) {
-                    patch_url = 'subscription/' + update.objects[0].id + '/';
-                    clean = false;
-                    update = {
-                        "lang": lang
-                    };
+                    if (update.objects[0].lang !== lang) {
+                        patch_url = 'subscription/' + update.objects[0].id + '/';
+                        clean = false;
+                        update = {
+                            "lang": lang
+                        };
                 }
                 } else if (update.objects.length >= 1) {
-                for (i=0; i<update.objects.length; i++) {
-                    if (update.objects[i].lang !== lang){
-                        update.objects[i].lang = lang;
-                        clean = false;
-                        patch_url = 'subscription/';
+                    for (i=0; i<update.objects.length; i++) {
+                        if (update.objects[i].lang !== lang){
+                            update.objects[i].lang = lang;
+                            clean = false;
+                            patch_url = 'subscription/';
+                        }
                     }
-                }
                 }
 
                 if (!clean) {

--- a/test/ussd_app.test.js
+++ b/test/ussd_app.test.js
@@ -82,7 +82,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.lang("en")
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "3", "2")
+                        .inputs("4", "2", "2")
                         .check.interaction({
                             state: "state_language_set",
                             reply: [
@@ -105,9 +105,10 @@ describe("MMC App", function() {
                             state: "state_main_menu",
                             reply: [
                                 "Medical Male Circumcision (MMC):",
-                                "1. Find a clinic",
-                                "2. Speak to an expert for FREE",
-                                "3. Get FREE SMSs about your MMC recovery",
+                                //"1. Find a clinic",  (disabled - see CCI-33)
+                                "1. Speak to an expert for FREE",
+                                "2. Get FREE SMSs about your MMC recovery",
+                                "3. Rate your clinic's MMC service",
                                 "4. More",
                             ].join("\n")
                         })
@@ -121,18 +122,18 @@ describe("MMC App", function() {
                             state: "state_main_menu",
                             reply: [
                                 "Medical Male Circumcision (MMC):",
-                                "1. Rate your clinic's MMC service",
-                                "2. Join Brothers for Life",
-                                "3. Change Language",
-                                "4. Exit",
-                                "5. Back",
+                                //"1. Rate your clinic's MMC service",
+                                "1. Join Brothers for Life",
+                                "2. Change Language",
+                                "3. Exit",
+                                "4. Back",
                             ].join("\n")
                         })
                         .run();
                 });
             });
 
-            describe("(Find a Clinic)", function() {
+            describe.skip("(Find a Clinic)", function() {
                 it("to state_healthsites (healthsites menu)", function() {
                     return tester
                         .setup.user.state("state_main_menu")
@@ -159,7 +160,7 @@ describe("MMC App", function() {
                 it("to state_op", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .input("3")
+                        .input("2")
                         .check.interaction({
                             state: "state_op",
                             reply: [
@@ -178,7 +179,7 @@ describe("MMC App", function() {
                 it("to state_pre_op", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "6")
+                        .inputs("2", "6")
                         .check.interaction({
                             state: "state_pre_op",
                             reply: [
@@ -193,7 +194,7 @@ describe("MMC App", function() {
                 it("to state_consent (menu options 1 & 2)", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "1")
+                        .inputs("2", "1")
                         .check.interaction({
                             state: "state_consent",
                             reply: [
@@ -211,7 +212,7 @@ describe("MMC App", function() {
                 it("to state_op_day (menu option 3,4,5)", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "4")
+                        .inputs("2", "4")
                         .check.interaction({
                             state: "state_op_day",
                             reply: "Please input the day you had your operation. "
@@ -222,7 +223,7 @@ describe("MMC App", function() {
                 it("to state_6week_notice; op date >= 6 weeks ago", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "5", "13")
+                        .inputs("2", "5", "13")
                         .check.interaction({
                             state: "state_6week_notice",
                             reply: [
@@ -239,7 +240,7 @@ describe("MMC App", function() {
                 it("to state_consent; op date < 6 weeks ago", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "4", "5")
+                        .inputs("2", "4", "5")
                         .check.interaction({
                             state: "state_consent",
                             reply: [
@@ -258,7 +259,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr("082111")
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "4", "5", "1")
+                        .inputs("2", "4", "5", "1")
                         .check.interaction({
                             state: "state_end_registration",
                             reply: [
@@ -280,7 +281,7 @@ describe("MMC App", function() {
                 it("to state_bfl_join", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "5", "13", "1")
+                        .inputs("2", "5", "13", "1")
                         .check.interaction({
                             state: "state_bfl_join",
                             reply: [
@@ -297,7 +298,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "5", "13", "1", "1")
+                        .inputs("2", "5", "13", "1", "1")
                         .check.interaction({
                             state: "state_main_menu"
                         })
@@ -312,7 +313,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "5", "13", "1", "2")
+                        .inputs("2", "5", "13", "1", "2")
                         .check.interaction({
                             state: "state_end"
                         })
@@ -326,7 +327,7 @@ describe("MMC App", function() {
                 it("to state_bfl_no_join", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "5", "13", "2")
+                        .inputs("2", "5", "13", "2")
                         .check.interaction({
                             state: "state_bfl_no_join",
                             reply: [
@@ -342,14 +343,15 @@ describe("MMC App", function() {
                 it("to state_main_menu (page 1) via BFL state", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "5", "13", "2", "1")
+                        .inputs("2", "5", "13", "2", "1")
                         .check.interaction({
                             state: "state_main_menu",
                             reply: [
                                 "Medical Male Circumcision (MMC):",
-                                "1. Find a clinic",
-                                "2. Speak to an expert for FREE",
-                                "3. Get FREE SMSs about your MMC recovery",
+                                //"1. Find a clinic",  (disabled - see CCI-33)
+                                "1. Speak to an expert for FREE",
+                                "2. Get FREE SMSs about your MMC recovery",
+                                "3. Rate your clinic's MMC service",
                                 "4. More",
                             ].join("\n")
                         })
@@ -359,7 +361,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "1", "2")
+                        .inputs("2", "1", "2")
                         .check.interaction({
                             state: "state_consent_withheld",
                             reply: [
@@ -375,7 +377,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "1", "2", "3")
+                        .inputs("2", "1", "2", "3")
                         .check.interaction({
                             state: "state_end",
                             reply: "Thanks for using the *120*662# MMC service! "
@@ -389,7 +391,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("3", "1", "2", "2")
+                        .inputs("2", "1", "2", "2")
                         .check.interaction({
                             state: "state_consent",
                             reply: [
@@ -410,7 +412,7 @@ describe("MMC App", function() {
                 it("to state_servicerating_location", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "1")
+                        .inputs("3")
                         .check.interaction({
                             state: "state_servicerating_location",
                             reply: [
@@ -522,7 +524,7 @@ describe("MMC App", function() {
                 it("to state_bfl_start", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2")
+                        .inputs("4", "1")
                         .check.interaction({
                             state: "state_bfl_start",
                             reply: [
@@ -539,7 +541,7 @@ describe("MMC App", function() {
                 it("to state_bfl_join", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2", "1")
+                        .inputs("4", "1", "1")
                         .check.interaction({
                             state: "state_bfl_join",
                             reply: [
@@ -555,7 +557,7 @@ describe("MMC App", function() {
                 it("to state_bfl_no_join", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2", "2")
+                        .inputs("4", "1", "2")
                         .check.interaction({
                             state: "state_bfl_no_join",
                             reply: [
@@ -572,7 +574,7 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2", "1", "2")
+                        .inputs("4", "1", "1", "2")
                         .check.interaction({
                             state: "state_end",
                             reply: "Thanks for using the *120*662# MMC service! "
@@ -590,7 +592,7 @@ describe("MMC App", function() {
                 it("to state_end via decision not to join", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2", "2", "2")
+                        .inputs("4", "1", "2", "2")
                         .check.interaction({
                             state: "state_end",
                             reply: "Thanks for using the *120*662# MMC service! "
@@ -604,14 +606,15 @@ describe("MMC App", function() {
                     return tester
                         .setup.user.addr('082111')
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2", "1", "1")
+                        .inputs("4", "1", "1", "1")
                         .check.interaction({
                             state: "state_main_menu",
                             reply: [
                                 "Medical Male Circumcision (MMC):",
-                                "1. Find a clinic",
-                                "2. Speak to an expert for FREE",
-                                "3. Get FREE SMSs about your MMC recovery",
+                                //"1. Find a clinic",  (disabled - see CCI-33)
+                                "1. Speak to an expert for FREE",
+                                "2. Get FREE SMSs about your MMC recovery",
+                                "3. Rate your clinic's MMC service",
                                 "4. More",
                             ].join("\n")
                         })
@@ -625,14 +628,15 @@ describe("MMC App", function() {
                 it("to state_main_menu via state_bfl_no_join", function() {
                     return tester
                         .setup.user.state("state_main_menu")
-                        .inputs("4", "2", "2", "1")
+                        .inputs("4", "1", "2", "1")
                         .check.interaction({
                             state: "state_main_menu",
                             reply: [
                                 "Medical Male Circumcision (MMC):",
-                                "1. Find a clinic",
-                                "2. Speak to an expert for FREE",
-                                "3. Get FREE SMSs about your MMC recovery",
+                                //"1. Find a clinic",  (disabled - see CCI-33)
+                                "1. Speak to an expert for FREE",
+                                "2. Get FREE SMSs about your MMC recovery",
+                                "3. Rate your clinic's MMC service",
                                 "4. More",
                             ].join("\n")
                         })


### PR DESCRIPTION
We have not received nor able to supply clinic locations for users.
Acceptance criteria:
1. Once a user dials in to the USSD line, they should not have clinic finder option as this does not exist as yet. In order to deliver better ux, this needs to not be shown to the user.
PS: Please keep in mind that we will use this module in the near future when we have clinic locations
