### PR TITLE
Add go-back-to-locate special character to no location results

### DIFF
--- a/go-app-ussd.js
+++ b/go-app-ussd.js
@@ -780,7 +780,7 @@ go.app = function() {
                 }
             }
 
-            return new LocationState(name, {
+            var ls = new LocationState(name, {
                 map_provider: new OpenStreetMap({
                     api_key: self.im.config.osm.api_key,
                     bounding_box: ["16.4500", "-22.1278", "32.8917", "-34.8333"],
@@ -803,12 +803,23 @@ go.app = function() {
                 error_question:
                     $("We could not find any results for that location. " +
                       "Please enter a street name or landmark close to the " +
-                      "area you are looking for. Make sure you use the " +
-                      "correct spelling"),
+                      "area you are looking for. If you would like for us " +
+                      "to try to locate you, press #"),
                 next: 'state_locate_clinic',
                 next_text: 'More',
                 previous_text: 'Back'
             });
+
+            // Override the initial handler, so that if it receives a # it goes
+            // back to the locate state
+            var old_initial_handler = ls.handlers.initial;
+            ls.handlers.initial = function(content) {
+                if (content === '#') {
+                    return ls.set_next_state('state_locate_permission');
+                }
+                return old_initial_handler(content);
+            };
+            return ls;
         });
 
         self.states.add('state_locate_clinic', function(name) {

--- a/src/ussd_app.js
+++ b/src/ussd_app.js
@@ -504,7 +504,7 @@ go.app = function() {
                 }
             }
 
-            return new LocationState(name, {
+            var ls = new LocationState(name, {
                 map_provider: new OpenStreetMap({
                     api_key: self.im.config.osm.api_key,
                     bounding_box: ["16.4500", "-22.1278", "32.8917", "-34.8333"],
@@ -527,12 +527,23 @@ go.app = function() {
                 error_question:
                     $("We could not find any results for that location. " +
                       "Please enter a street name or landmark close to the " +
-                      "area you are looking for. Make sure you use the " +
-                      "correct spelling"),
+                      "area you are looking for. If you would like for us " +
+                      "to try to locate you, press #"),
                 next: 'state_locate_clinic',
                 next_text: 'More',
                 previous_text: 'Back'
             });
+
+            // Override the initial handler, so that if it receives a # it goes
+            // back to the locate state
+            var old_initial_handler = ls.handlers.initial;
+            ls.handlers.initial = function(content) {
+                if (content === '#') {
+                    return ls.set_next_state('state_locate_permission');
+                }
+                return old_initial_handler(content);
+            };
+            return ls;
         });
 
         self.states.add('state_locate_clinic', function(name) {

--- a/test/ussd_app.test.js
+++ b/test/ussd_app.test.js
@@ -85,6 +85,14 @@ describe("MMC App", function() {
                 ]
             });
 
+            locations.push({
+                query: "Lonely Street",
+                key: "osm_api_key",
+                bounding_box: ["16.4500", "-22.1278", "32.8917", "-34.8333"],
+                address_limit: 4,
+                response_data: []
+            });
+
             tester
                 .setup.char_limit(182)
                 .setup.config.app({
@@ -886,6 +894,54 @@ describe("MMC App", function() {
                                             'location:lat'], '3.33');
                                     })
                                     .run();
+                            });
+                        });
+
+                        describe("if there are no location options", function() {
+                            it("should display the error message asking them to retry", function() {
+                                return tester
+                                    .setup.user.addr('082111')
+                                    .setup.user.state('state_healthsites')
+                                    .inputs(
+                                        { content: '1',
+                                          provider: 'CellC' },  // state_healthsites
+                                        'Lonely Street'  // state_suburb
+                                    )
+                                    .check.interaction({
+                                        state: 'state_suburb',
+                                        reply: [
+                                            "We could not find any results for that location. Please ",
+                                            "enter a street name or landmark close to the area you are ",
+                                            "looking for. If you would like for us to try to locate you, ",
+                                            "press #"
+                                        ].join("")
+                                    })
+                                    .run();
+                            });
+
+                            describe("if they then type # to retry location search", function() {
+                                it("should take them back to the locate permission screen", function() {
+                                    return tester
+                                    .setup.user.addr('082111')
+                                    .setup.user.state('state_healthsites')
+                                    .inputs(
+                                        { content: '1',
+                                          provider: 'CellC' },  // state_healthsites
+                                        'Lonely Street',  // state_suburb
+                                        '#' // state_suburb error display
+                                    )
+                                    .check.interaction({
+                                        state: 'state_locate_permission',
+                                        reply: [
+                                            "Thanks! We will now locate your approximate " +
+                                            "position and then send you an SMS with your " +
+                                            "nearest clinic.",
+                                            "1. Continue",
+                                            "2. No don't locate me"
+                                        ].join('\n')
+                                    })
+                                    .run();
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
If there are no location results for a user's location search, we want them to be able to go back and have the network attempt to locate their phone.

Since this is a free text input, we've chosen the special character `#` to represent the user's desire to go back to location search, as it is least likely to be used in an actual search.